### PR TITLE
Added a cleanup function to remove authorization from axios header

### DIFF
--- a/pages/hackathon/[slug]/index.js
+++ b/pages/hackathon/[slug]/index.js
@@ -51,6 +51,7 @@ export default function Hackathon() {
                 })
                 .finally(() => setLocalLoading(false))
         }
+        return () => delete axios.defaults.headers.common['Authorization']
     }, [slug, token])
 
     const [submissions, setSubmisssions] = useState([])


### PR DESCRIPTION
As the Axios authorization header has been set to token at the time of mounting, when the dependencies for the useEffect changes, the Axios would still have the same token as authorization even if the user has logged out unless the page is refreshed, so I added a cleanup function that removes the authorization header on every unmount so that if the token is not there, the API call would not have the previous token.