### PR TITLE
Fix Spinner on Participants Section of Hackathon Page

### DIFF
--- a/pages/hackathon/[slug]/index.js
+++ b/pages/hackathon/[slug]/index.js
@@ -543,8 +543,8 @@ function Participants({ slug }) {
                 .catch((err) => {
                     console.error(err)
                 })
+                .finally(() => setLoading(false))
         }
-        setLoading(false)
     }, [slug])
 
     return (


### PR DESCRIPTION
The state of `loading` was being changed to `false` again well before fetching the data from the backend.