### PR TITLE
Fixed the date bug on submission page

### DIFF
--- a/pages/submission/[id].js
+++ b/pages/submission/[id].js
@@ -295,7 +295,7 @@ export default function SubmissionDetail() {
                                         <tr>
                                             <td>Start Date</td>
                                             <td>
-                                                {Date(
+                                                {new Date(
                                                     submission.hackathon.start
                                                 ).toString()}{" "}
                                             </td>
@@ -303,7 +303,7 @@ export default function SubmissionDetail() {
                                         <tr>
                                             <td>End Date</td>
                                             <td>
-                                                {Date(
+                                                {new Date(
                                                     submission.hackathon.end
                                                 ).toString()}{" "}
                                             </td>


### PR DESCRIPTION
On the submission page, the dates were showing incorrectly as the current date. I have fixed it to show the actual start and end dates for hackathon.